### PR TITLE
Feat/interactive business card

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,6 +43,12 @@ android {
 
 dependencies {
 
+    implementation("com.google.code.gson:gson:2.10.1")
+    implementation("net.sourceforge.ezagile:ez-vcard:0.11.4")
+    implementation("com.journeyapps:zxing-android-embedded:4.3.0") {
+        exclude(group = "com.android.support")
+    }
+    implementation("com.google.zxing:core:3.5.0")
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
         minSdk = 30
         targetSdk = 35
         versionCode = 1
-        versionName = "1.0"
+        versionName = "1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -43,12 +43,12 @@ android {
 
 dependencies {
 
-    implementation("com.google.code.gson:gson:2.10.1")
-    implementation("net.sourceforge.ezagile:ez-vcard:0.11.4")
+    implementation(libs.gson)
+    implementation(libs.googlecode.ez.vcard)
     implementation("com.journeyapps:zxing-android-embedded:4.3.0") {
         exclude(group = "com.android.support")
     }
-    implementation("com.google.zxing:core:3.5.0")
+    implementation(libs.core)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/src/main/java/com/gleidsonlm/businesscard/MainActivity.kt
+++ b/app/src/main/java/com/gleidsonlm/businesscard/MainActivity.kt
@@ -1,5 +1,11 @@
 package com.gleidsonlm.businesscard
 
+// Log is already imported
+// androidx.compose.foundation.Image is already imported
+// Other necessary imports like MaterialTheme, Surface, padding, Alignment are already present
+// androidx.compose.material3.Button is already imported
+// androidx.compose.foundation.layout.fillMaxSize is already imported
+// UserData is already imported via com.gleidsonlm.businesscard.ui.UserData
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
@@ -12,18 +18,16 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Email
-import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.rounded.AccountCircle
 import androidx.compose.material.icons.rounded.Call
 import androidx.compose.material.icons.rounded.Email
@@ -31,33 +35,18 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import android.util.Log
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.platform.LocalContext
-import com.gleidsonlm.businesscard.ui.UserInputScreen
-import com.gleidsonlm.businesscard.ui.UserData
-import com.gleidsonlm.businesscard.util.DataStore
-import com.gleidsonlm.businesscard.util.VCardHelper
-import android.content.Intent
-// Log is already imported
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.foundation.layout.Box
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
-// androidx.compose.foundation.Image is already imported
-import androidx.compose.ui.window.Dialog
-// Other necessary imports like MaterialTheme, Surface, padding, Alignment are already present
-// androidx.compose.material3.Button is already imported
-// androidx.compose.foundation.layout.fillMaxSize is already imported
-// UserData is already imported via com.gleidsonlm.businesscard.ui.UserData
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -66,8 +55,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
 import androidx.core.net.toUri
+import com.gleidsonlm.businesscard.ui.UserData
+import com.gleidsonlm.businesscard.ui.UserInputScreen
 import com.gleidsonlm.businesscard.ui.theme.BusinessCardTheme
+import com.gleidsonlm.businesscard.util.DataStore
+import com.gleidsonlm.businesscard.util.VCardHelper
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -152,6 +146,8 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 private fun BusinessCardApp(userData: UserData?, onShowQrCodeClicked: () -> Unit) {
+    val context = LocalContext.current
+
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
@@ -164,7 +160,9 @@ private fun BusinessCardApp(userData: UserData?, onShowQrCodeClicked: () -> Unit
         )
     }
     Column (
-        modifier = Modifier.fillMaxSize().padding(16.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
         verticalArrangement = Arrangement.Bottom,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/app/src/main/java/com/gleidsonlm/businesscard/ui/UserData.kt
+++ b/app/src/main/java/com/gleidsonlm/businesscard/ui/UserData.kt
@@ -1,0 +1,10 @@
+package com.gleidsonlm.businesscard.ui
+
+data class UserData(
+    val fullName: String,
+    val title: String,
+    val phoneNumber: String,
+    val emailAddress: String,
+    val company: String,
+    val website: String
+)

--- a/app/src/main/java/com/gleidsonlm/businesscard/ui/UserInputScreen.kt
+++ b/app/src/main/java/com/gleidsonlm/businesscard/ui/UserInputScreen.kt
@@ -1,0 +1,103 @@
+package com.gleidsonlm.businesscard.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.gleidsonlm.businesscard.ui.UserData
+
+@Composable
+fun UserInputScreen(onSaveClicked: (UserData) -> Unit) {
+    var fullName by remember { mutableStateOf("") }
+    var title by remember { mutableStateOf("") }
+    var phoneNumber by remember { mutableStateOf("") }
+    var emailAddress by remember { mutableStateOf("") }
+    var company by remember { mutableStateOf("") }
+    var website by remember { mutableStateOf("") }
+
+    Surface {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            OutlinedTextField(
+                value = fullName,
+                onValueChange = { fullName = it },
+                label = { Text("Full Name") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedTextField(
+                value = title,
+                onValueChange = { title = it },
+                label = { Text("Title") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedTextField(
+                value = phoneNumber,
+                onValueChange = { phoneNumber = it },
+                label = { Text("Phone Number") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedTextField(
+                value = emailAddress,
+                onValueChange = { emailAddress = it },
+                label = { Text("Email Address") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedTextField(
+                value = company,
+                onValueChange = { company = it },
+                label = { Text("Company") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedTextField(
+                value = website,
+                onValueChange = { website = it },
+                label = { Text("Website") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(
+                onClick = {
+                    val userData = UserData(
+                        fullName = fullName,
+                        title = title,
+                        phoneNumber = phoneNumber,
+                        emailAddress = emailAddress,
+                        company = company,
+                        website = website
+                    )
+                    onSaveClicked(userData)
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Save")
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun UserInputScreenPreview() {
+    UserInputScreen(onSaveClicked = {})
+}

--- a/app/src/main/java/com/gleidsonlm/businesscard/util/DataStore.kt
+++ b/app/src/main/java/com/gleidsonlm/businesscard/util/DataStore.kt
@@ -1,0 +1,31 @@
+package com.gleidsonlm.businesscard.util
+
+import android.content.Context
+import com.gleidsonlm.businesscard.ui.UserData
+import com.google.gson.Gson
+
+object DataStore {
+
+    private const val PREFS_NAME = "BusinessCardPrefs"
+    private const val USER_DATA_KEY = "user_data_json"
+
+    fun saveUserData(context: Context, userData: UserData) {
+        val sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val editor = sharedPreferences.edit()
+        val gson = Gson()
+        val jsonUserData = gson.toJson(userData)
+        editor.putString(USER_DATA_KEY, jsonUserData)
+        editor.apply()
+    }
+
+    fun loadUserData(context: Context): UserData? {
+        val sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val jsonUserData = sharedPreferences.getString(USER_DATA_KEY, null)
+        return if (jsonUserData != null) {
+            val gson = Gson()
+            gson.fromJson(jsonUserData, UserData::class.java)
+        } else {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/gleidsonlm/businesscard/util/VCardHelper.kt
+++ b/app/src/main/java/com/gleidsonlm/businesscard/util/VCardHelper.kt
@@ -1,0 +1,88 @@
+package com.gleidsonlm.businesscard.util
+
+import com.gleidsonlm.businesscard.ui.UserData
+import ezvcard.Ezvcard
+import ezvcard.VCard
+import ezvcard.property.StructuredName
+import ezvcard.property.Telephone
+import ezvcard.property.Url
+import ezvcard.property.Email // Added Email import
+import ezvcard.property.Organization // Added Organization import
+import android.graphics.Bitmap
+import android.util.Log
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.WriterException
+import com.journeyapps.barcodescanner.BarcodeEncoder
+
+object VCardHelper {
+
+    fun generateVCardString(userData: UserData): String {
+        val vcard = VCard()
+
+        // Formatted Name (FN)
+        if (userData.fullName.isNotBlank()) {
+            vcard.setFormattedName(userData.fullName)
+        }
+
+        // Structured Name (N)
+        if (userData.fullName.isNotBlank()) {
+            val n = StructuredName()
+            val nameParts = userData.fullName.trim().split(" ", limit = 2)
+            n.given = nameParts.getOrNull(0)
+            if (nameParts.size > 1) {
+                n.family = nameParts.getOrNull(1)
+            }
+            vcard.structuredName = n
+        }
+
+        // Title
+        if (userData.title.isNotBlank()) {
+            vcard.addTitle(userData.title)
+        }
+
+        // Phone
+        if (userData.phoneNumber.isNotBlank()) {
+            vcard.addTelephone(Telephone(userData.phoneNumber))
+        }
+
+        // Email
+        if (userData.emailAddress.isNotBlank()) {
+            val email = Email(userData.emailAddress) // Create Email property
+            vcard.addEmail(email)
+        }
+
+        // Organization (Company)
+        if (userData.company.isNotBlank()) {
+            val organization = Organization() // Create Organization property
+            organization.addValue(userData.company)
+            vcard.addOrganization(organization)
+        }
+
+        // Website URL
+        if (userData.website.isNotBlank()) {
+            try {
+                val websiteUrl = Url(userData.website)
+                vcard.addUrl(websiteUrl)
+            } catch (e: IllegalArgumentException) {
+                // Handle invalid URL if necessary, e.g., log it or skip adding
+                System.err.println("Invalid URL format for website: ${userData.website}")
+            }
+        }
+
+        return Ezvcard.write(vcard).go()
+    }
+
+    fun generateQRCodeBitmap(vCardString: String, size: Int = 512): Bitmap? {
+        val barcodeEncoder = BarcodeEncoder()
+        return try {
+            barcodeEncoder.encodeBitmap(vCardString, BarcodeFormat.QR_CODE, size, size)
+        } catch (e: WriterException) {
+            Log.e("VCardHelper", "Failed to generate QR Code Bitmap", e)
+            null
+        } catch (e: Exception) {
+            // Catch any other unexpected errors during bitmap generation
+            Log.e("VCardHelper", "Unexpected error generating QR Code Bitmap", e)
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/gleidsonlm/businesscard/util/VCardHelper.kt
+++ b/app/src/main/java/com/gleidsonlm/businesscard/util/VCardHelper.kt
@@ -1,18 +1,18 @@
 package com.gleidsonlm.businesscard.util
 
-import com.gleidsonlm.businesscard.ui.UserData
-import ezvcard.Ezvcard
-import ezvcard.VCard
-import ezvcard.property.StructuredName
-import ezvcard.property.Telephone
-import ezvcard.property.Url
-import ezvcard.property.Email // Added Email import
-import ezvcard.property.Organization // Added Organization import
 import android.graphics.Bitmap
 import android.util.Log
+import com.gleidsonlm.businesscard.ui.UserData
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.WriterException
 import com.journeyapps.barcodescanner.BarcodeEncoder
+import ezvcard.Ezvcard
+import ezvcard.VCard
+import ezvcard.property.Email
+import ezvcard.property.Organization
+import ezvcard.property.StructuredName
+import ezvcard.property.Telephone
+import ezvcard.property.Url
 
 object VCardHelper {
 
@@ -42,7 +42,8 @@ object VCardHelper {
 
         // Phone
         if (userData.phoneNumber.isNotBlank()) {
-            vcard.addTelephone(Telephone(userData.phoneNumber))
+//            vcard.addTelephone(Telephone(userData.phoneNumber))
+            vcard.addTelephoneNumber(Telephone(userData.phoneNumber))
         }
 
         // Email
@@ -54,7 +55,7 @@ object VCardHelper {
         // Organization (Company)
         if (userData.company.isNotBlank()) {
             val organization = Organization() // Create Organization property
-            organization.addValue(userData.company)
+            organization.getValues().add(userData.company)
             vcard.addOrganization(organization)
         }
 
@@ -66,6 +67,7 @@ object VCardHelper {
             } catch (e: IllegalArgumentException) {
                 // Handle invalid URL if necessary, e.g., log it or skip adding
                 System.err.println("Invalid URL format for website: ${userData.website}")
+                System.err.println("Error message: ${e.message}")
             }
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,22 @@
 [versions]
 agp = "8.9.3"
+core = "3.5.0"
+ezVcardVersion = "0.12.1"
+gson = "2.10.1"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.9.0"
+lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
-composeBom = "2025.05.01"
+composeBom = "2025.06.00"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+core = { module = "com.google.zxing:core", version.ref = "core" }
+googlecode-ez-vcard = { module = "com.googlecode.ez-vcard:ez-vcard", version.ref = "ezVcardVersion" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
This commit was generated by Google Joules and introduces several enhancements to the Business Card app:

1.  **User Input:**
    *   Added a new screen allowing you to input your personal information (name, title, phone, email, company, website).
    *   Implemented state management for the input fields using Jetpack Compose's `mutableStateOf`.

2.  **Dynamic Display:**
    *   The main business card screen now dynamically displays the information entered by you.
    *   You can navigate between the input screen and the card display.

3.  **Data Persistence:**
    *   Your data is now saved to SharedPreferences (serialized as JSON using Gson).
    *   The app loads saved data on startup, allowing information to persist across sessions.

4.  **vCard Generation & Sharing:**
    *   Integrated the 'ez-vcard' library.
    *   Added functionality to generate a vCard string from your data.
    *   Implemented a "Share vCard" feature using an Android share intent.

5.  **QR Code Generation & Display:**
    *   Integrated the 'zxing-android-embedded' library.
    *   Added functionality to generate a QR code bitmap from the vCard data.
    *   Implemented a "Show QR Code" feature that displays the QR code in a dialog.

These changes transform the static business card into an interactive application, providing a foundation for you to manage and share your contact information effectively. This also serves as a learning path covering key Android development concepts like UI with Jetpack Compose, state management, navigation, data persistence, and third-party library integration.