### PR TITLE
Feat/interactive business card

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
         minSdk = 30
         targetSdk = 35
         versionCode = 1
-        versionName = "1.0"
+        versionName = "1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -43,12 +43,12 @@ android {
 
 dependencies {
 
-    implementation("com.google.code.gson:gson:2.10.1")
-    implementation("net.sourceforge.ezagile:ez-vcard:0.11.4")
+    implementation(libs.gson)
+    implementation(libs.googlecode.ez.vcard)
     implementation("com.journeyapps:zxing-android-embedded:4.3.0") {
         exclude(group = "com.android.support")
     }
-    implementation("com.google.zxing:core:3.5.0")
+    implementation(libs.core)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
         exclude(group = "com.android.support")
     }
     implementation(libs.core)
+    implementation(libs.coil.compose)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -23,6 +29,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/gleidsonlm/businesscard/MainActivity.kt
+++ b/app/src/main/java/com/gleidsonlm/businesscard/MainActivity.kt
@@ -1,5 +1,11 @@
 package com.gleidsonlm.businesscard
 
+// Log is already imported
+// androidx.compose.foundation.Image is already imported
+// Other necessary imports like MaterialTheme, Surface, padding, Alignment are already present
+// androidx.compose.material3.Button is already imported
+// androidx.compose.foundation.layout.fillMaxSize is already imported
+// UserData is already imported via com.gleidsonlm.businesscard.ui.UserData
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
@@ -12,18 +18,16 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Email
-import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.rounded.AccountCircle
 import androidx.compose.material.icons.rounded.Call
 import androidx.compose.material.icons.rounded.Email
@@ -31,33 +35,18 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import android.util.Log
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.platform.LocalContext
-import com.gleidsonlm.businesscard.ui.UserInputScreen
-import com.gleidsonlm.businesscard.ui.UserData
-import com.gleidsonlm.businesscard.util.DataStore
-import com.gleidsonlm.businesscard.util.VCardHelper
-import android.content.Intent
-// Log is already imported
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.foundation.layout.Box
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
-// androidx.compose.foundation.Image is already imported
-import androidx.compose.ui.window.Dialog
-// Other necessary imports like MaterialTheme, Surface, padding, Alignment are already present
-// androidx.compose.material3.Button is already imported
-// androidx.compose.foundation.layout.fillMaxSize is already imported
-// UserData is already imported via com.gleidsonlm.businesscard.ui.UserData
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -66,8 +55,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
 import androidx.core.net.toUri
+import com.gleidsonlm.businesscard.ui.UserData
+import com.gleidsonlm.businesscard.ui.UserInputScreen
 import com.gleidsonlm.businesscard.ui.theme.BusinessCardTheme
+import com.gleidsonlm.businesscard.util.DataStore
+import com.gleidsonlm.businesscard.util.VCardHelper
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -152,6 +146,8 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 private fun BusinessCardApp(userData: UserData?, onShowQrCodeClicked: () -> Unit) {
+    val context = LocalContext.current
+
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
@@ -164,7 +160,9 @@ private fun BusinessCardApp(userData: UserData?, onShowQrCodeClicked: () -> Unit
         )
     }
     Column (
-        modifier = Modifier.fillMaxSize().padding(16.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
         verticalArrangement = Arrangement.Bottom,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/app/src/main/java/com/gleidsonlm/businesscard/MainActivity.kt
+++ b/app/src/main/java/com/gleidsonlm/businesscard/MainActivity.kt
@@ -1,11 +1,18 @@
 package com.gleidsonlm.businesscard
 
 // Log is already imported
+// import com.gleidsonlm.businesscard.R // R is usually available without explicit import in .kt files in module
+// painterResource and stringResource are already imported
 // androidx.compose.foundation.Image is already imported
 // Other necessary imports like MaterialTheme, Surface, padding, Alignment are already present
 // androidx.compose.material3.Button is already imported
 // androidx.compose.foundation.layout.fillMaxSize is already imported
 // UserData is already imported via com.gleidsonlm.businesscard.ui.UserData
+// import androidx.compose.ui.platform.LocalContext // Already imported
+// import androidx.compose.runtime.LaunchedEffect // Already imported
+// import androidx.compose.ui.graphics.ImageBitmap // Already imported
+// import androidx.compose.ui.graphics.asImageBitmap // Already imported
+// import com.gleidsonlm.businesscard.util.VCardHelper // Already imported
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
@@ -27,11 +34,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AccountCircle
 import androidx.compose.material.icons.rounded.Call
 import androidx.compose.material.icons.rounded.Email
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -44,10 +54,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -55,13 +66,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.core.net.toUri
+import coil.compose.AsyncImage
 import com.gleidsonlm.businesscard.ui.UserData
 import com.gleidsonlm.businesscard.ui.UserInputScreen
 import com.gleidsonlm.businesscard.ui.theme.BusinessCardTheme
 import com.gleidsonlm.businesscard.util.DataStore
 import com.gleidsonlm.businesscard.util.VCardHelper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -71,7 +84,7 @@ class MainActivity : ComponentActivity() {
             val context = LocalContext.current
             var currentData by remember { mutableStateOf<UserData?>(null) }
             var showInputScreen by remember { mutableStateOf(true) }
-            var qrCodeImageBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
+            // var qrCodeImageBitmap by remember { mutableStateOf<ImageBitmap?>(null) } // DELETED
 
             LaunchedEffect(Unit) {
                 val loadedData = DataStore.loadUserData(context)
@@ -84,28 +97,20 @@ class MainActivity : ComponentActivity() {
             BusinessCardTheme {
                 Surface(modifier = Modifier.fillMaxSize()) { // Ensure Surface fills size for Box alignment
                     if (showInputScreen) {
-                        UserInputScreen(onSaveClicked = { userData ->
-                            DataStore.saveUserData(context, userData)
-                            currentData = userData
-                            showInputScreen = false
-                            Log.d("MainActivity", "UserData Saved: $userData")
-                        })
+                        UserInputScreen(
+                            existingData = currentData, // Pass currentData to prefill
+                            onSaveClicked = { userData ->
+                                DataStore.saveUserData(context, userData)
+                                currentData = userData
+                                showInputScreen = false
+                                Log.d("MainActivity", "UserData Saved: $userData")
+                            }
+                        )
                     } else {
                         Box(modifier = Modifier.fillMaxSize()) {
                             BusinessCardApp(
-                                userData = currentData,
-                                onShowQrCodeClicked = {
-                                    if (currentData != null) {
-                                        // Ensure currentData is not null before using !!
-                                        currentData?.let { nnCurrentData ->
-                                            val vCardString = VCardHelper.generateVCardString(nnCurrentData)
-                                            val qrBitmap = VCardHelper.generateQRCodeBitmap(vCardString)
-                                            if (qrBitmap != null) {
-                                                qrCodeImageBitmap = qrBitmap.asImageBitmap()
-                                            }
-                                        }
-                                    }
-                                }
+                                userData = currentData
+                                // onShowQrCodeClicked lambda removed
                             )
                             Button(
                                 onClick = { showInputScreen = true },
@@ -118,26 +123,8 @@ class MainActivity : ComponentActivity() {
                         }
                     }
 
-                    // Dialog for QR Code display
-                    if (qrCodeImageBitmap != null) {
-                        Dialog(onDismissRequest = { qrCodeImageBitmap = null }) {
-                            Surface( // Wrap content in a Surface for theming and shape
-                                shape = MaterialTheme.shapes.medium,
-                                color = MaterialTheme.colorScheme.surface, // Use theme surface color
-                                contentColor = MaterialTheme.colorScheme.onSurface // Use theme onSurface color
-                            ) {
-                                Box(
-                                    contentAlignment = Alignment.Center,
-                                    modifier = Modifier.padding(16.dp) // Add padding around the image
-                                ) {
-                                    Image(
-                                        bitmap = qrCodeImageBitmap!!, // qrCodeImageBitmap is checked not null here
-                                        contentDescription = "Contact QR Code"
-                                    )
-                                }
-                            }
-                        }
-                    }
+                    // Dialog for QR Code display // DELETED
+                    // if (qrCodeImageBitmap != null) { ... } // DELETED
                 }
             }
         }
@@ -145,86 +132,127 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-private fun BusinessCardApp(userData: UserData?, onShowQrCodeClicked: () -> Unit) {
-    val context = LocalContext.current
+private fun BusinessCardApp(userData: UserData?) {
+    var qrCodeImageBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
+
+    LaunchedEffect(userData) {
+        qrCodeImageBitmap = if (userData != null) {
+            val vCardString = withContext(Dispatchers.Default) {
+                VCardHelper.generateVCardString(userData)
+            }
+            val androidBitmap = withContext(Dispatchers.Default) {
+                VCardHelper.generateQRCodeBitmap(vCardString)
+            }
+            androidBitmap?.asImageBitmap()
+        } else {
+            null
+        }
+    }
 
     Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        BusinessCardFace(
-            image = painterResource(R.drawable.avatar),
-            actualFullName = userData?.fullName ?: stringResource(R.string.full_name),
-            actualTitle = userData?.title ?: stringResource(R.string.title),
-        )
-    }
-    Column (
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.Bottom,
-        horizontalAlignment = Alignment.CenterHorizontally
+            .padding(16.dp)
+        // horizontalAlignment = Alignment.CenterHorizontally // Kept for overall centering
     ) {
-        BusinessCardLink(
-            icon = Icons.Rounded.Call,
-            actualLinkText = userData?.phoneNumber ?: stringResource(R.string.link_text_call),
-            actualLinkUrl = "tel:${userData?.phoneNumber ?: ""}",
-        )
-        BusinessCardLink(
-            icon = Icons.Rounded.Email,
-            actualLinkText = userData?.emailAddress ?: stringResource(R.string.link_text_email),
-            actualLinkUrl = "mailto:${userData?.emailAddress ?: ""}",
-        )
-        BusinessCardLink(
-            icon = Icons.Rounded.AccountCircle, // Kept icon, text/URL now from website
-            actualLinkText = userData?.website ?: stringResource(R.string.link_text_in),
-            actualLinkUrl = userData?.website ?: "#",
-        )
-        Spacer(modifier = Modifier.height(16.dp)) // Reduced spacer before new button
-        Button(
-            onClick = {
-                if (userData != null) {
-                    val vCardString = VCardHelper.generateVCardString(userData)
-                    val intent = Intent(Intent.ACTION_SEND).apply {
-                        type = "text/x-vcard"
-                        putExtra(Intent.EXTRA_TEXT, vCardString)
-                    }
-                    try {
-                        context.startActivity(Intent.createChooser(intent, "Share vCard"))
-                    } catch (e: Exception) {
-                        Log.e("ShareVCard", "Failed to start activity for sharing vCard", e)
-                        // Optionally, show a Toast to the user that sharing failed
-                        // Toast.makeText(context, "Could not share vCard", Toast.LENGTH_SHORT).show()
-                    }
-                } else {
-                    Log.w("ShareVCard", "User data is null, cannot share vCard.")
-                    // Optionally, show a Toast to the user
-                    // Toast.makeText(context, "No data to share", Toast.LENGTH_SHORT).show()
-                }
-            },
-            modifier = Modifier.fillMaxWidth() // Optional: make button full width
+        // Top 1/3: QR Code
+        Box(
+            modifier = Modifier
+                .weight(1f) // Can adjust weight if more/less space is needed
+                .fillMaxWidth()
+                .padding(bottom = 8.dp),
+            contentAlignment = Alignment.Center
         ) {
-            Text("Share vCard")
+            if (qrCodeImageBitmap != null) {
+                Image(
+                    bitmap = qrCodeImageBitmap!!,
+                    contentDescription = stringResource(R.string.qr_code_content_description),
+                    modifier = Modifier.size(160.dp) // Adjust size as needed
+                )
+            } else if (userData != null) {
+                // Show a loading indicator if userData is present but QR code is still generating
+                CircularProgressIndicator()
+            } else {
+                // Placeholder text if no user data (and thus no QR code)
+                Text(stringResource(R.string.qr_code_placeholder_text))
+            }
         }
-        Spacer(modifier = Modifier.height(8.dp)) // Spacer between buttons
-        Button(
-            onClick = { onShowQrCodeClicked() },
-            modifier = Modifier.fillMaxWidth()
+
+        // Middle 1/3: Avatar & Info (BusinessCardFace)
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
+            contentAlignment = Alignment.Center
         ) {
-            Text("Show QR Code")
+            BusinessCardFace(
+                avatarUri = userData?.avatarUri,
+                actualFullName = userData?.fullName ?: stringResource(id = R.string.full_name),
+                actualTitle = userData?.title ?: stringResource(id = R.string.title)
+            )
         }
-        Spacer(modifier = Modifier.height(40.dp)) // Adjusted spacer after new button
+
+        // Bottom 1/3: Links & Actions
+        Column(
+            modifier = Modifier
+                .weight(1f) // Can adjust weight
+                .fillMaxWidth()
+                .padding(top = 8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center // Vertically center content in this section
+        ) {
+            BusinessCardLink(
+                icon = Icons.Rounded.Call,
+                actualLinkText = userData?.phoneNumber?.takeIf { it.isNotBlank() } ?: stringResource(id = R.string.link_text_call),
+                actualLinkUrl = "tel:${userData?.phoneNumber?.takeIf { it.isNotBlank() } ?: ""}"
+            )
+            Spacer(Modifier.height(8.dp))
+            BusinessCardLink(
+                icon = Icons.Rounded.Email,
+                actualLinkText = userData?.emailAddress?.takeIf { it.isNotBlank() } ?: stringResource(id = R.string.link_text_email),
+                actualLinkUrl = "mailto:${userData?.emailAddress?.takeIf { it.isNotBlank() } ?: ""}"
+            )
+            Spacer(Modifier.height(8.dp))
+            BusinessCardLink(
+                icon = Icons.Rounded.AccountCircle,
+                actualLinkText = userData?.website?.takeIf { it.isNotBlank() } ?: stringResource(id = R.string.link_text_in),
+                actualLinkUrl = userData?.website?.takeIf { it.isNotBlank() } ?: "#"
+            )
+            Spacer(Modifier.height(16.dp))
+
+            val context = LocalContext.current // Context for the share Intent
+            Button(
+                onClick = {
+                    if (userData != null) {
+                        val vCardString = VCardHelper.generateVCardString(userData)
+                        val intent = Intent(Intent.ACTION_SEND).apply {
+                            type = "text/x-vcard"
+                            putExtra(Intent.EXTRA_TEXT, vCardString)
+                        }
+                        try {
+                            context.startActivity(Intent.createChooser(intent, "Share vCard"))
+                        } catch (e: Exception) {
+                            Log.e("ShareVCard", "Failed to start activity for sharing vCard", e)
+                        }
+                    } else {
+                        Log.w("ShareVCard", "User data is null, cannot share vCard.")
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(stringResource(R.string.share_vcard_button))
+            }
+        }
     }
 }
 
 @Composable
 private fun BusinessCardFace(
-    image: Painter,
+    avatarUri: String?, // Changed from image: Painter
     actualFullName: String,
     actualTitle: String,
     modifier: Modifier = Modifier
-    ) {
+) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
@@ -232,9 +260,15 @@ private fun BusinessCardFace(
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.background)
     ) {
-        Image(
-            painter = image,
-            contentDescription = null,
+        AsyncImage(
+            model = avatarUri ?: R.drawable.avatar, // Use URI or default drawable
+            contentDescription = stringResource(R.string.user_avatar_content_description),
+            modifier = Modifier
+                .size(120.dp)
+                .clip(CircleShape),
+            contentScale = ContentScale.Crop,
+            placeholder = painterResource(id = R.drawable.avatar), // Default avatar as placeholder
+            error = painterResource(id = R.drawable.avatar)       // Default avatar for error
         )
         Spacer(Modifier.height(32.dp))
         Text(
@@ -315,15 +349,15 @@ fun BusinessCardPreview() {
             phoneNumber = "1234567890",
             emailAddress = "sample@example.com",
             company = "Sample Company",
-            website = "https.sample.com"
+            website = "https.sample.com",
+            avatarUri = null // avatarUri is already null in sampleData
         )
         // Surface is important for theme colors to apply correctly in preview
         Surface(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background
         ) {
-            // For preview, pass a dummy lambda for onShowQrCodeClicked
-            BusinessCardApp(userData = sampleData, onShowQrCodeClicked = {})
+            BusinessCardApp(userData = sampleData) // onShowQrCodeClicked argument removed
         }
     }
 }

--- a/app/src/main/java/com/gleidsonlm/businesscard/ui/UserData.kt
+++ b/app/src/main/java/com/gleidsonlm/businesscard/ui/UserData.kt
@@ -6,5 +6,6 @@ data class UserData(
     val phoneNumber: String,
     val emailAddress: String,
     val company: String,
-    val website: String
+    val website: String,
+    val avatarUri: String? = null
 )

--- a/app/src/main/java/com/gleidsonlm/businesscard/ui/UserInputScreen.kt
+++ b/app/src/main/java/com/gleidsonlm/businesscard/ui/UserInputScreen.kt
@@ -1,10 +1,21 @@
 package com.gleidsonlm.businesscard.ui
 
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
@@ -14,19 +25,102 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.gleidsonlm.businesscard.ui.UserData
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
+import coil.compose.AsyncImage
+import com.gleidsonlm.businesscard.R
+import java.io.File
+import java.math.BigInteger
+import java.security.MessageDigest
+
+// MD5 Helper function
+private fun String.toMd5(): String {
+    return try {
+        val md = MessageDigest.getInstance("MD5")
+        val messageDigest = md.digest(this.trim().lowercase().toByteArray())
+        val no = BigInteger(1, messageDigest)
+        var hashtext = no.toString(16)
+        while (hashtext.length < 32) {
+            hashtext = "0$hashtext"
+        }
+        hashtext
+    } catch (e: Exception) {
+        Log.e("MD5", "Error generating MD5 hash", e)
+        "" // Return empty string or handle error as appropriate
+    }
+}
 
 @Composable
-fun UserInputScreen(onSaveClicked: (UserData) -> Unit) {
-    var fullName by remember { mutableStateOf("") }
-    var title by remember { mutableStateOf("") }
-    var phoneNumber by remember { mutableStateOf("") }
-    var emailAddress by remember { mutableStateOf("") }
-    var company by remember { mutableStateOf("") }
-    var website by remember { mutableStateOf("") }
+fun UserInputScreen(existingData: UserData?, onSaveClicked: (UserData) -> Unit) {
+    var fullName by remember { mutableStateOf(existingData?.fullName ?: "") }
+    var title by remember { mutableStateOf(existingData?.title ?: "") }
+    var phoneNumber by remember { mutableStateOf(existingData?.phoneNumber ?: "") }
+    var emailAddress by remember { mutableStateOf(existingData?.emailAddress ?: "") }
+    var company by remember { mutableStateOf(existingData?.company ?: "") }
+    var website by remember { mutableStateOf(existingData?.website ?: "") }
+    var avatarUri by remember { mutableStateOf(existingData?.avatarUri) }
+
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        uri?.let {
+            avatarUri = it.toString()
+        }
+    }
+
+    val context = LocalContext.current
+    val requestPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted: Boolean ->
+        if (isGranted) {
+            imagePickerLauncher.launch("image/*") // For gallery permission
+        } else {
+            Log.w("Permission", "Storage permission denied.")
+        }
+    }
+
+    var tempCameraUri by remember { mutableStateOf<Uri?>(null) }
+
+    fun createImageUri(context: Context): Uri {
+        val imageFile = File(context.cacheDir, "images/pic_${System.currentTimeMillis()}.jpg")
+        imageFile.parentFile?.mkdirs()
+        return FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.provider",
+            imageFile
+        )
+    }
+
+    val takePictureLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.TakePicture()
+    ) { success: Boolean ->
+        if (success) {
+            tempCameraUri?.let { uri ->
+                avatarUri = uri.toString()
+            }
+        }
+        tempCameraUri = null // Reset after use
+    }
+
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted: Boolean ->
+        if (isGranted) {
+            val newUri = createImageUri(context)
+            tempCameraUri = newUri
+            takePictureLauncher.launch(newUri)
+        } else {
+            Log.w("Permission", "CAMERA permission denied.")
+        }
+    }
 
     Surface {
         Column(
@@ -34,6 +128,85 @@ fun UserInputScreen(onSaveClicked: (UserData) -> Unit) {
                 .fillMaxWidth()
                 .padding(16.dp)
         ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                AsyncImage(
+                    model = avatarUri ?: R.drawable.avatar,
+                    contentDescription = "Avatar Preview",
+                    modifier = Modifier
+                        .size(100.dp)
+                        .clip(CircleShape),
+                    placeholder = painterResource(id = R.drawable.avatar),
+                    error = painterResource(id = R.drawable.avatar),
+                    contentScale = ContentScale.Crop
+                )
+            }
+            Button(
+                onClick = {
+                    val permissionToRequest = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        Manifest.permission.READ_MEDIA_IMAGES
+                    } else {
+                        Manifest.permission.READ_EXTERNAL_STORAGE
+                    }
+
+                    when (ContextCompat.checkSelfPermission(context, permissionToRequest)) {
+                        PackageManager.PERMISSION_GRANTED -> {
+                            imagePickerLauncher.launch("image/*")
+                        }
+                        else -> {
+                            requestPermissionLauncher.launch(permissionToRequest)
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Choose from Gallery")
+            }
+            Spacer(modifier = Modifier.height(8.dp)) // Spacer between gallery and photo buttons
+            Button(
+                onClick = {
+                    when (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA)) {
+                        PackageManager.PERMISSION_GRANTED -> {
+                            val newUri = createImageUri(context)
+                            tempCameraUri = newUri
+                            takePictureLauncher.launch(newUri)
+                        }
+                        else -> {
+                            cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Take Photo")
+            }
+            Spacer(modifier = Modifier.height(8.dp)) // Spacer between photo and gravatar buttons
+            Button(
+                onClick = {
+                    if (emailAddress.isNotBlank()) {
+                        val emailHash = emailAddress.toMd5()
+                        if (emailHash.isNotBlank()) {
+                            val gravatarUrl = "https://www.gravatar.com/avatar/$emailHash?s=200&d=mp"
+                            avatarUri = gravatarUrl // Update the avatarUri state
+                            Log.i("Gravatar", "Attempting to load Gravatar from: $gravatarUrl")
+                        } else {
+                            Log.w("Gravatar", "Email hash is blank, cannot fetch Gravatar.")
+                            // Optionally, inform the user that hashing failed
+                        }
+                    } else {
+                        Log.w("Gravatar", "Email address is blank, cannot fetch Gravatar.")
+                        // Optionally, inform the user to enter an email
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Fetch Gravatar")
+            }
+            Spacer(modifier = Modifier.height(16.dp))
             OutlinedTextField(
                 value = fullName,
                 onValueChange = { fullName = it },
@@ -84,7 +257,8 @@ fun UserInputScreen(onSaveClicked: (UserData) -> Unit) {
                         phoneNumber = phoneNumber,
                         emailAddress = emailAddress,
                         company = company,
-                        website = website
+                        website = website,
+                        avatarUri = avatarUri
                     )
                     onSaveClicked(userData)
                 },
@@ -99,5 +273,5 @@ fun UserInputScreen(onSaveClicked: (UserData) -> Unit) {
 @Preview(showBackground = true)
 @Composable
 fun UserInputScreenPreview() {
-    UserInputScreen(onSaveClicked = {})
+    UserInputScreen(existingData = null, onSaveClicked = {})
 }

--- a/app/src/main/java/com/gleidsonlm/businesscard/util/VCardHelper.kt
+++ b/app/src/main/java/com/gleidsonlm/businesscard/util/VCardHelper.kt
@@ -42,7 +42,6 @@ object VCardHelper {
 
         // Phone
         if (userData.phoneNumber.isNotBlank()) {
-//            vcard.addTelephone(Telephone(userData.phoneNumber))
             vcard.addTelephoneNumber(Telephone(userData.phoneNumber))
         }
 
@@ -56,7 +55,7 @@ object VCardHelper {
         if (userData.company.isNotBlank()) {
             val organization = Organization() // Create Organization property
             organization.getValues().add(userData.company)
-            vcard.addOrganization(organization)
+            vcard.organization = organization
         }
 
         // Website URL
@@ -65,9 +64,7 @@ object VCardHelper {
                 val websiteUrl = Url(userData.website)
                 vcard.addUrl(websiteUrl)
             } catch (e: IllegalArgumentException) {
-                // Handle invalid URL if necessary, e.g., log it or skip adding
-                System.err.println("Invalid URL format for website: ${userData.website}")
-                System.err.println("Error message: ${e.message}")
+                Log.e("VCardHelper", "Invalid URL format for website: ${userData.website}", e)
             }
         }
 

--- a/app/src/main/java/com/gleidsonlm/businesscard/util/VCardHelper.kt
+++ b/app/src/main/java/com/gleidsonlm/businesscard/util/VCardHelper.kt
@@ -1,18 +1,18 @@
 package com.gleidsonlm.businesscard.util
 
-import com.gleidsonlm.businesscard.ui.UserData
-import ezvcard.Ezvcard
-import ezvcard.VCard
-import ezvcard.property.StructuredName
-import ezvcard.property.Telephone
-import ezvcard.property.Url
-import ezvcard.property.Email // Added Email import
-import ezvcard.property.Organization // Added Organization import
 import android.graphics.Bitmap
 import android.util.Log
+import com.gleidsonlm.businesscard.ui.UserData
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.WriterException
 import com.journeyapps.barcodescanner.BarcodeEncoder
+import ezvcard.Ezvcard
+import ezvcard.VCard
+import ezvcard.property.Email
+import ezvcard.property.Organization
+import ezvcard.property.StructuredName
+import ezvcard.property.Telephone
+import ezvcard.property.Url
 
 object VCardHelper {
 
@@ -42,7 +42,8 @@ object VCardHelper {
 
         // Phone
         if (userData.phoneNumber.isNotBlank()) {
-            vcard.addTelephone(Telephone(userData.phoneNumber))
+//            vcard.addTelephone(Telephone(userData.phoneNumber))
+            vcard.addTelephoneNumber(Telephone(userData.phoneNumber))
         }
 
         // Email
@@ -54,7 +55,7 @@ object VCardHelper {
         // Organization (Company)
         if (userData.company.isNotBlank()) {
             val organization = Organization() // Create Organization property
-            organization.addValue(userData.company)
+            organization.getValues().add(userData.company)
             vcard.addOrganization(organization)
         }
 
@@ -66,6 +67,7 @@ object VCardHelper {
             } catch (e: IllegalArgumentException) {
                 // Handle invalid URL if necessary, e.g., log it or skip adding
                 System.err.println("Invalid URL format for website: ${userData.website}")
+                System.err.println("Error message: ${e.message}")
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,8 @@
     <string name="link_url_in">https://www.linkedin.com/in/gleidsonlm/</string>
     <string name="link_text_call">Phone</string>
     <string name="link_url_call">tel:+5583991446999</string>
+    <string name="user_avatar_content_description">User Avatar</string>
+    <string name="qr_code_content_description">Contact QR Code</string>
+    <string name="qr_code_placeholder_text">Enter details to generate QR Code</string>
+    <string name="share_vcard_button">Share vCard</string>
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="my_images" path="images/" />
+    <!-- Using cache-path for temporary image files.
+         Alternatively, files-path could be used for more permanent app files.
+         The 'path' attribute specifies a subdirectory within the cache directory.
+    -->
+</paths>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,22 @@
 [versions]
 agp = "8.9.3"
+core = "3.5.0"
+ezVcardVersion = "0.12.1"
+gson = "2.10.1"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.9.0"
+lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
-composeBom = "2025.05.01"
+composeBom = "2025.06.00"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+core = { module = "com.google.zxing:core", version.ref = "core" }
+googlecode-ez-vcard = { module = "com.googlecode.ez-vcard:ez-vcard", version.ref = "ezVcardVersion" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.9.3"
+coilCompose = "2.5.0"
 core = "3.5.0"
 ezVcardVersion = "0.12.1"
 gson = "2.10.1"
@@ -14,6 +15,7 @@ composeBom = "2025.06.00"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 core = { module = "com.google.zxing:core", version.ref = "core" }
 googlecode-ez-vcard = { module = "com.googlecode.ez-vcard:ez-vcard", version.ref = "ezVcardVersion" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }


### PR DESCRIPTION
feat: Integrate QR code directly into main card display
This commit refactors the main business card UI (`BusinessCardApp`) to display the QR code directly on the screen, rather than in a dialog.

Key changes:

1.  **New 3-Section Layout:**
    *   The `BusinessCardApp` Composable now divides the screen vertically into three weighted sections:
        *   **Top third:** Displays the generated QR code for your vCard. Includes a loading indicator while the QR code is being generated and placeholder text if no user data is available.
        *   **Middle third:** Displays your avatar (dynamically loaded), full name, and title via the `BusinessCardFace` Composable.
        *   **Bottom third:** Contains action links (phone, email, website) and the "Share vCard" button.

2.  **QR Code Generation in `BusinessCardApp`:**
    *   The logic for generating the QR code (as an `ImageBitmap`) is now handled directly within `BusinessCardApp` using a `LaunchedEffect` that triggers when `userData` changes.
    *   The previous "Show QR Code" button and dialog functionality have been removed.

3.  **UI Refinements:**
    *   String resources were added for new text elements (e.g., QR code content description, placeholder text).
    *   The layout uses `Modifier.weight` for flexible distribution of space among the three sections.
    *   Content within each section is appropriately aligned and spaced.

This change aims to make the QR code more immediately accessible to you and provides a more integrated visual experience on the business card.