### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appdome.yml
+++ b/.github/workflows/appdome.yml
@@ -1,4 +1,6 @@
 name: Appdome build-2secure
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/gleidsonlm/android_business_card/security/code-scanning/1](https://github.com/gleidsonlm/android_business_card/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's purpose (building and securing an app using Appdome), it likely does not need write access to the repository contents. Therefore, we can set `contents: read` as the permission.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. If specific jobs require different permissions, additional `permissions` blocks can be added within those jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
