### PR TITLE
Refactor: Change Edit Button to an Icon

### DIFF
--- a/app/src/main/java/com/gleidsonlm/businesscard/MainActivity.kt
+++ b/app/src/main/java/com/gleidsonlm/businesscard/MainActivity.kt
@@ -22,8 +22,10 @@ import androidx.compose.material.icons.rounded.Call
 import androidx.compose.material.icons.rounded.Email
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.Share
+import androidx.compose.material.icons.rounded.Edit // Added for the edit icon
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton // Added for IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -115,7 +117,7 @@ class MainActivity : ComponentActivity() {
                             BusinessCardApp(
                                 businessCardViewModel = businessCardViewModel
                             )
-                            Button(
+                            IconButton( // Changed Button to IconButton
                                 onClick = {
                                     val currentCardData = businessCardViewModel.currentData.value
                                     userInputViewModel.loadExistingData(currentCardData)
@@ -125,7 +127,10 @@ class MainActivity : ComponentActivity() {
                                     .align(Alignment.TopEnd)
                                     .padding(16.dp)
                             ) {
-                                Text(stringResource(R.string.edit))
+                                Icon( // Added Icon composable
+                                    imageVector = Icons.Rounded.Edit, // Set the icon
+                                    contentDescription = stringResource(R.string.edit) // Set content description
+                                )
                             }
                         }
                     }


### PR DESCRIPTION
Replaced the text-based Edit Button with an IconButton using Material Design's 'Edit' icon. This change aligns with modern UI practices, providing a cleaner and more intuitive user experience.

Key changes:
- Modified MainActivity.kt to use IconButton instead of Button.
- Incorporated Icons.Rounded.Edit for the visual representation.
- Ensured all existing onClick functionality and modifiers are preserved.

Addresses issue #17.