### PR TITLE
Android Building and Protecting with Appdome

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
 - main
 
 pool:
-  vmImage: 'macos-15'
+  vmImage: 'ubuntu-latest'
 
 variables:
   buildDir: '$(Build.SourcesDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ steps:
     Token: '$(APPDOME_API_TOKEN)'
     FusionSetId: '$(APPDOME_FUSION_SET_ID)'
     OutputFileName: 'android-business-card-protected'
-    KeystoreFile: 'AppdomeLabs-Android-Signing.jks'
+    KeystoreFile: '$(DownloadKeystore.secureFilePath)'
     KeystorePass: '$(APPDOME_SIGN_KEYSTORE_PASSWORD)'
     KeystoreAlias: '$(APPDOME_SIGN_KEY_ALIAS)'
     KeyPass: '$(APPDOME_SIGN_KEY_PASSWORD)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pool:
 variables:
   buildDir: '$(Build.SourcesDirectory)'
   appDir: '$(buildDir)/app'
-  outputAab: '$(appDir)/build/outputs/bundle/debug/app-debug.aab'
+  outputAab: '$(appDir)/build/outputs/bundle/$(buildVariant)/app-$(buildVariant).aab'
 
 steps:
 
@@ -24,15 +24,15 @@ steps:
 
 
 # Build the Android App Bundle (AAB)
-- task: Gradle@3
+- task: Gradle@4 
   displayName: 'Assemble Android App Bundle (Debug)'
   inputs:
-    workingDirectory: '$(buildDir)'
     gradleWrapperFile: 'gradlew'
+    tasks: 'clean :app:bundle'
+    publishJUnitResults: false
+    javaHomeOption: 'JDKVersion'
     gradleOptions: '-Xmx4096m'
-    publishJUnitResults: true
-    testResultsFiles: '**/TEST-*.xml'
-    tasks: 'clean :app:bundleDebug'
+    workingDirectory: '$(buildDir)'
 
 # Publish the AAB as a pipeline artifact
 - task: PublishPipelineArtifact@1
@@ -46,7 +46,7 @@ steps:
 - task: DownloadSecureFile@1
   name: DownloadKeystore
   inputs:
-    secureFile: 'AppdomeLabs-Android-Signing.jks'
+    secureFile: '$(APPDOME_SIGN_KEYSTORE)'
 
 # Protect and sign the AAB with Appdome Build-2Secure
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,32 +1,33 @@
-# Android
-# Build your Android project with Gradle.
-# Add steps that test, sign, and distribute the APK, save build artifacts, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/android
-
 trigger:
 - main
-
-
 
 pool:
   vmImage: 'macos-latest'
 
+variables:
+  buildDir: '$(Build.SourcesDirectory)'
+  appDir: '$(buildDir)/app'
+
 steps:
 
+# Download google-services.json securely
 - task: DownloadSecureFile@1
   name: DownloadGoogleServices
   inputs:
     secureFile: 'google-services.json'
 
+# Copy the file to the correct location
 - script: |
-    cp $(DownloadGoogleServices.secureFilePath) $(Build.SourcesDirectory)/app/google-services.json
+    cp $(DownloadGoogleServices.secureFilePath) $(appDir)/google-services.json
   displayName: 'Copy google-services.json to app directory'
 
+# Build the Android App Bundle (AAB)
 - task: Gradle@2
+  displayName: 'Assemble Android App Bundle (Debug)'
   inputs:
-    workingDirectory: ''
+    workingDirectory: '$(buildDir)'
     gradleWrapperFile: 'gradlew'
-    gradleOptions: '-Xmx3072m'
-    publishJUnitResults: false
+    gradleOptions: '-Xmx4096m'
+    publishJUnitResults: true
     testResultsFiles: '**/TEST-*.xml'
-    tasks: 'assembleDebug'
+    tasks: 'clean :app:bundleDebug'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
 - main
 
 pool:
-  vmImage: 'macos-latest'
+  vmImage: 'macos-15'
 
 variables:
   buildDir: '$(Build.SourcesDirectory)'
@@ -21,8 +21,9 @@ steps:
     cp $(DownloadGoogleServices.secureFilePath) $(appDir)/google-services.json
   displayName: 'Copy google-services.json to app directory'
 
+
 # Build the Android App Bundle (AAB)
-- task: Gradle@2
+- task: Gradle@3
   displayName: 'Assemble Android App Bundle (Debug)'
   inputs:
     workingDirectory: '$(buildDir)'
@@ -31,3 +32,11 @@ steps:
     publishJUnitResults: true
     testResultsFiles: '**/TEST-*.xml'
     tasks: 'clean :app:bundleDebug'
+
+# Publish the AAB as a pipeline artifact
+- task: PublishPipelineArtifact@1
+  displayName: 'Publish AAB as Artifact'
+  inputs:
+    targetPath: '$(outputAab)'
+    artifact: 'android-business-card-aab'
+    publishLocation: 'pipeline'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,32 @@
+# Android
+# Build your Android project with Gradle.
+# Add steps that test, sign, and distribute the APK, save build artifacts, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/android
+
+trigger:
+- main
+
+
+
+pool:
+  vmImage: 'macos-latest'
+
+steps:
+
+- task: DownloadSecureFile@1
+  name: DownloadGoogleServices
+  inputs:
+    secureFile: 'google-services.json'
+
+- script: |
+    cp $(DownloadGoogleServices.secureFilePath) $(Build.SourcesDirectory)/app/google-services.json
+  displayName: 'Copy google-services.json to app directory'
+
+- task: Gradle@2
+  inputs:
+    workingDirectory: ''
+    gradleWrapperFile: 'gradlew'
+    gradleOptions: '-Xmx3072m'
+    publishJUnitResults: false
+    testResultsFiles: '**/TEST-*.xml'
+    tasks: 'assembleDebug'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,11 +2,12 @@ trigger:
 - main
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'macos-15'
 
 variables:
   buildDir: '$(Build.SourcesDirectory)'
   appDir: '$(buildDir)/app'
+  outputAab: '$(appDir)/build/outputs/bundle/debug/app-debug.aab'
 
 steps:
 
@@ -16,7 +17,7 @@ steps:
   inputs:
     secureFile: 'google-services.json'
 
-# Copy the file to the correct location
+# Copy google-services.json to app directory
 - script: |
     cp $(DownloadGoogleServices.secureFilePath) $(appDir)/google-services.json
   displayName: 'Copy google-services.json to app directory'
@@ -40,3 +41,26 @@ steps:
     targetPath: '$(outputAab)'
     artifact: 'android-business-card-aab'
     publishLocation: 'pipeline'
+
+# Download keystore file from Secure Files
+- task: DownloadSecureFile@1
+  name: DownloadKeystore
+  inputs:
+    secureFile: 'AppdomeLabs-Android-Signing.jks'
+
+# Protect and sign the AAB with Appdome Build-2Secure
+
+- task: Build-2Secure@0
+  displayName: 'Protect and Sign AAB with Appdome'
+  inputs:
+    Platform: 'android'
+    Sign: 'signOnAppdome'
+    App: '$(outputAab)'
+    Token: '$(APPDOME_API_TOKEN)'
+    FusionSetId: '$(APPDOME_FUSION_SET_ID)'
+    OutputFileName: 'android-business-card-protected'
+    KeystoreFile: 'AppdomeLabs-Android-Signing.jks'
+    KeystorePass: '$(APPDOME_SIGN_KEYSTORE_PASSWORD)'
+    KeystoreAlias: '$(APPDOME_SIGN_KEY_ALIAS)'
+    KeyPass: '$(APPDOME_SIGN_KEY_PASSWORD)'
+    BuildWithLogs: true


### PR DESCRIPTION
This PR introduces a CI/CD pipeline for building and protecting Android applications using Azure DevOps. The pipeline automates the build process for Android App Bundles (AAB) and integrates Appdome's security protection services.
- Configures Azure pipeline to build Android App Bundle in debug mode
- Integrates secure file handling for Google Services configuration and signing keystore
- Implements Appdome Build-2Secure task for app protection and signing