### PR TITLE
feat: Integrate Firebase Analytics and Crashlytics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,10 @@ When assisting with this project, please adhere to the following best practices:
     *   Always use `read_files()` to get the latest version of a file before attempting to modify it. This prevents working with stale information.
     *   Utilize `ls()` and `grep()` for exploration and to locate relevant code sections or files.
     *   If you encounter compilation errors or test failures after a change, attempt to diagnose and fix them. Clearly communicate the error and your proposed solution.
+    *   **Testing with Firebase:** Before running tests, ensure a placeholder `google-services.json` file exists at `app/google-services.json` to prevent build failures. A minimal file can be created with a command like `echo '{"project_info": {"project_id": "example"}}' > app/google-services.json`.
 
 4.  **Understanding `AGENTS.md`:**
+
     *   Always check for `AGENTS.md` files in the repository, especially in the root or relevant module directories.
     *   Adhere to the instructions and guidelines provided herein unless explicitly overridden by the user for a specific task.
     *   If programmatic checks are mentioned in `AGENTS.md` (none currently, but for future reference), ensure they pass after your changes.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.hilt.plugin)
     alias(libs.plugins.kotlin.parcelize)
+    alias(libs.plugins.google.gms.google.services)
 }
 
 android {
@@ -15,8 +16,8 @@ android {
         applicationId = "com.gleidsonlm.businesscard"
         minSdk = 31
         targetSdk = 36
-        versionCode = 1754414964
-        versionName = "August 5, 2025"
+        versionCode = 1754478576
+        versionName = "August 6, 2025"
     }
 
     buildTypes {
@@ -75,6 +76,9 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.hilt.android)
     implementation(libs.androidx.hilt.navigation.compose)
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.analytics)
+    implementation(libs.firebase.crashlytics)
     ksp(libs.hilt.android.compiler)
     testImplementation(libs.junit)
     testImplementation(libs.androidx.arch.core.testing)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ coilCompose = "2.7.0"
 core = "3.5.3"
 coreVersion = "1.7.0"
 ezVcardVersion = "0.12.1"
+firebaseBom = "33.1.0"
 gson = "2.13.1"
 hiltNavigationCompose = "1.2.0"
 kotlin = "2.2.0"
@@ -34,6 +35,9 @@ androidx-rules = { module = "androidx.test:rules", version.ref = "coreVersion" }
 androidx-runner = { module = "androidx.test:runner", version.ref = "runner" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 core = { module = "com.google.zxing:core", version.ref = "core" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
+firebase-auth = { module = "com.google.firebase:firebase-auth" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 googlecode-ez-vcard = { module = "com.googlecode.ez-vcard:ez-vcard", version.ref = "ezVcardVersion" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ coilCompose = "2.7.0"
 core = "3.5.3"
 coreVersion = "1.7.0"
 ezVcardVersion = "0.12.1"
-firebaseBom = "33.1.0"
+firebaseBom = "34.0.0"
 gson = "2.13.1"
 hiltNavigationCompose = "1.2.0"
 kotlin = "2.2.0"
@@ -35,8 +35,8 @@ androidx-rules = { module = "androidx.test:rules", version.ref = "coreVersion" }
 androidx-runner = { module = "androidx.test:runner", version.ref = "runner" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 core = { module = "com.google.zxing:core", version.ref = "core" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics", version.ref = "firebaseCrashlytics" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
-firebase-auth = { module = "com.google.firebase:firebase-auth" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 googlecode-ez-vcard = { module = "com.googlecode.ez-vcard:ez-vcard", version.ref = "ezVcardVersion" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
@@ -57,7 +57,6 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
-firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics", version.ref = "firebaseCrashlytics" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }


### PR DESCRIPTION
This PR integrates Firebase into the application to enable analytics and crash reporting.

Changes include:
- Adding the Google Services plugin to apply Google services to the Android application.
- Importing the Firebase Bill of Materials (BOM) to manage dependency versions.
- Including the Firebase Analytics and Crashlytics dependencies to enable event logging and crash reporting.
- Updating AGENTS.md to include instructions for handling the google-services.json file during testing.